### PR TITLE
Update 7-data-structures.md

### DIFF
--- a/spec/7-data-structures.md
+++ b/spec/7-data-structures.md
@@ -4,7 +4,7 @@
 
 {% endhint %}
 
-<pre class="language-html" data-overflow="wrap"><code class="lang-html"><strong>The proposed resource model showing the relationship between data objects that are used by this Building Block is illustrated in the diagram below.
+<strong>The proposed resource model showing the relationship between data objects that are used by this Building Block is illustrated in the diagram below.
 </strong>
 ## 7.1 Standards
 
@@ -729,4 +729,3 @@ Contains any additional or extended inputs required to confirm an order. This is
 | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | form     | object  | [Form](#7324-form)                                                                                     |
 | required | boolean | Indicates whether the form data is mandatorily required by the Provider Platform to confirm the order. |
-</code></pre>


### PR DESCRIPTION
Fixed formatting issue in `7-data-structures.md` : Removed <code>/</code> tags generated on Gitbook

<!--- Provide a short summary of your changes in the Title above. Prefix with the associated issue number. -->
Gitbook had generated `<code></code>` tags when directly pasting markdown in the content. 
## Description
<!--- Describe your changes in detail -->
Removed the `<code></code>` tags and now the format is fixed
## Related Issue
NA

## Motivation and Context
this change is required because directly pasting markdown content on Gitbook is getting incorrectly parsed. The technical committee recommended directly commiting to GitHub to resolve the issue. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
